### PR TITLE
PDF圧縮機能を追加

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -369,6 +369,23 @@ test = ["certifi (>=2024)", "cryptography-vectors (==44.0.0)", "pretend (>=0.7)"
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
+name = "deprecated"
+version = "1.2.18"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+files = [
+    {file = "Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec"},
+    {file = "deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d"},
+]
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "setuptools", "tox"]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 description = "Distro - an OS platform information API"
@@ -1041,6 +1058,67 @@ docs = ["sphinx", "sphinx-argparse"]
 image = ["Pillow"]
 
 [[package]]
+name = "pikepdf"
+version = "9.5.2"
+description = "Read and write PDFs with Python, powered by qpdf"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pikepdf-9.5.2-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:412bd45c806ea3d7ef25a04b24a777c87efef725ac7f047d1fc71062049d2625"},
+    {file = "pikepdf-9.5.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:bee6e7f93533c0d5ee66f65547963a56f85d0469b1134ddfc13439cf45b0e989"},
+    {file = "pikepdf-9.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e89a0a74917feb0a9ab7450f83dc6b821d0c20ae28ee42cdee9b484ff3e114b7"},
+    {file = "pikepdf-9.5.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae4517cf8bc356609e1174c27309e128a78e155d6663e38346710bbe0c4373f4"},
+    {file = "pikepdf-9.5.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea94021603bd71d6a3ccc22b1d6799ff1ad4190224472550f73801b3beceed"},
+    {file = "pikepdf-9.5.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0154a4b4d558ff488a662597128075f26956fa4b8682ce7f1bca7b383a7d6a6e"},
+    {file = "pikepdf-9.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:4aad61ce4b10239a7079e7553aed07620b049037cfeb5c972f4e5be56c9f875e"},
+    {file = "pikepdf-9.5.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:b3aa2beec989035451d54a36443230995adda13677b2809a2d1f55767b040120"},
+    {file = "pikepdf-9.5.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:0ec92b93d912ff8864c661f38b622062a5dc0e2296a86acc372dcf3828421095"},
+    {file = "pikepdf-9.5.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24b5f7b4ffa17e3a0db232d68353ffc24dd4bd3658094e27dbdf6ee393753987"},
+    {file = "pikepdf-9.5.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f422e477c4408189e219ae27f2089e661e472877bacf99c3e077e03937f3cec"},
+    {file = "pikepdf-9.5.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:63c564102cf39c6518a803e1653a820255d6283e27ad6517cbd60a224e56aba1"},
+    {file = "pikepdf-9.5.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4397d3dccda0f047b19d21fbcc50eae36b9745cf697d1eca4dd998bd5c12a952"},
+    {file = "pikepdf-9.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:ee8ee014b10599e65c3edd38aaf100e1bb67d888ba52004e09eff830bf5ca845"},
+    {file = "pikepdf-9.5.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:20dc868d7e032afc614d2a7baea87fd45b025044313a9fd8b12add537a5b77a5"},
+    {file = "pikepdf-9.5.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1ab0f76e376c2ccf247ee8ec6e7b2ecb4100a54ae2b9d0ed633f66d4425188cb"},
+    {file = "pikepdf-9.5.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e771712910d47ae16d4b5f314922cb3f090ddab7ea06db4872ef519420c64ba8"},
+    {file = "pikepdf-9.5.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcc3d3bdcf3f63a0aece21afa9d517872cc375ec120d3e4143ff7ad5203cd9e4"},
+    {file = "pikepdf-9.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:353b23c5b75d7042c99bbb72dcc78063bc04599b5ec6516c301102e42afdff50"},
+    {file = "pikepdf-9.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af5b7bbcaf80ef981fb3ff8a1ce9d8c4b4af96b35e71947525f70362235c784c"},
+    {file = "pikepdf-9.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:4bced2322e060fc79b6b933428d63fa5d65e0de0060f8f661401b45f14194e62"},
+    {file = "pikepdf-9.5.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:fadb3eac9a4c109d9a13a7f3687091333d160469983db319fcc7fd51bb74548b"},
+    {file = "pikepdf-9.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:103b73642c9ab175e93c771673bca565acad8b78d4a3af0f68319ab7ec6af990"},
+    {file = "pikepdf-9.5.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc6a52ca6ad8bbd06ec84fb5c8ef5ed151d4fd360e2e6ffcabe2dc899cd87a76"},
+    {file = "pikepdf-9.5.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406a98e2fc6fa2522d249921e261f3303a4e563e3ed9de6e924ad303df9aeb97"},
+    {file = "pikepdf-9.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f0d19fb0646da6d69a86b28cb0a80ffde5a519f65cf79cc12451551977015fd2"},
+    {file = "pikepdf-9.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:518fa733807d805930b1d122579806c43128cd9d298980a547f250f4cb8e0a4f"},
+    {file = "pikepdf-9.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:ff6044857ef3eef9eed61121e1189df816fbbe5363fa0dc1c446bd145f074ee3"},
+    {file = "pikepdf-9.5.2-cp39-cp39-macosx_13_0_x86_64.whl", hash = "sha256:b75b04ee87a216c94e75e947e1921ff6426f1589cb245ab3894f67ea10bf5e34"},
+    {file = "pikepdf-9.5.2-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:217ab7fc70ce2c4befef39a07c8d0f1598f5d3e46d440514aab4a4655e954cfc"},
+    {file = "pikepdf-9.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7b191c782999fc7cfac01343db7096a30235385b80341f8eb2c704516fc432c"},
+    {file = "pikepdf-9.5.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc30dcf70fdce9a0bfd110e1afa0c21ef5f17ba8c743745651b1e3ac7c0ff122"},
+    {file = "pikepdf-9.5.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:52d8a6cb3d9e8ad5b9a5517fd6238203359c832b641fb1b254328708ae59e9e5"},
+    {file = "pikepdf-9.5.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8bec3ac14a56a9435b8ccd34c56b7a331caf0c960344f68570e551a899989a69"},
+    {file = "pikepdf-9.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:101b0718599b404e9235f51e024f4b555aec95fcbfa78d67e5edde8950e411f4"},
+    {file = "pikepdf-9.5.2-pp310-pypy310_pp73-macosx_13_0_x86_64.whl", hash = "sha256:3b8b47ca9a8fdad67edc802fb8435bed17cc164a3768f57c30c46ff428015c1d"},
+    {file = "pikepdf-9.5.2-pp310-pypy310_pp73-macosx_14_0_arm64.whl", hash = "sha256:1f27d95c7ce2dea03758af44f06edd1e6f8bf226aa804fa0ee7fa1d6ced21707"},
+    {file = "pikepdf-9.5.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:466f9936433dcc1e3c78ae6371e2ed6ac42fe23d8bb10e255fb9ef1aa36d82f3"},
+    {file = "pikepdf-9.5.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:65e395ed795b8eb2991b7838f96dd51ecab14c57ecdad82e07ad98560ae090d2"},
+    {file = "pikepdf-9.5.2.tar.gz", hash = "sha256:190b3bb4891a7a154315f505d7dcd557ef21e8130cea8b78eb9646f8d67072ed"},
+]
+
+[package.dependencies]
+Deprecated = "*"
+lxml = ">=4.8"
+packaging = "*"
+Pillow = ">=10.0.1"
+
+[package.extras]
+dev = ["pre-commit", "typer"]
+docs = ["Sphinx (>=3)", "sphinx-autoapi", "sphinx-design", "sphinx-issues", "sphinx-rtd-theme", "tomli"]
+mypy = ["lxml-stubs", "types-Pillow", "types-requests", "types-setuptools"]
+test = ["attrs (>=20.2.0)", "coverage[toml]", "hypothesis (>=6.36)", "numpy (>=1.21.0)", "psutil (>=5.9)", "pybind11", "pytest (>=6.2.5)", "pytest-cov (>=3.0.0)", "pytest-timeout (>=2.1.0)", "pytest-xdist (>=2.5.0)", "python-dateutil (>=2.8.1)", "python-xmp-toolkit (>=2.0.1)", "tomli"]
+
+[[package]]
 name = "pillow"
 version = "11.1.0"
 description = "Python Imaging Library (Fork)"
@@ -1309,6 +1387,25 @@ files = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "5.3.0"
+description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pypdf-5.3.0-py3-none-any.whl", hash = "sha256:d7b6db242f5f8fdb4990ae11815c394b8e1b955feda0befcce862efd8559c181"},
+    {file = "pypdf-5.3.0.tar.gz", hash = "sha256:08393660dfea25b27ec6fe863fb2f2248e6270da5103fae49e9dea8178741951"},
+]
+
+[package.extras]
+crypto = ["cryptography"]
+cryptodome = ["PyCryptodome"]
+dev = ["black", "flit", "pip-tools", "pre-commit (<2.18.0)", "pytest-cov", "pytest-socket", "pytest-timeout", "pytest-xdist", "wheel"]
+docs = ["myst_parser", "sphinx", "sphinx_rtd_theme"]
+full = ["Pillow (>=8.0.0)", "cryptography"]
+image = ["Pillow (>=8.0.0)"]
+
+[[package]]
 name = "pytest"
 version = "8.3.4"
 description = "pytest: simple powerful testing with Python"
@@ -1552,6 +1649,94 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "wrapt"
+version = "1.17.2"
+description = "Module for decorators, wrappers and monkey patching."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984"},
+    {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b5e251054542ae57ac7f3fba5d10bfff615b6c2fb09abeb37d2f1463f841ae22"},
+    {file = "wrapt-1.17.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:80dd7db6a7cb57ffbc279c4394246414ec99537ae81ffd702443335a61dbf3a7"},
+    {file = "wrapt-1.17.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a6e821770cf99cc586d33833b2ff32faebdbe886bd6322395606cf55153246c"},
+    {file = "wrapt-1.17.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b60fb58b90c6d63779cb0c0c54eeb38941bae3ecf7a73c764c52c88c2dcb9d72"},
+    {file = "wrapt-1.17.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b870b5df5b71d8c3359d21be8f0d6c485fa0ebdb6477dda51a1ea54a9b558061"},
+    {file = "wrapt-1.17.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4011d137b9955791f9084749cba9a367c68d50ab8d11d64c50ba1688c9b457f2"},
+    {file = "wrapt-1.17.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:1473400e5b2733e58b396a04eb7f35f541e1fb976d0c0724d0223dd607e0f74c"},
+    {file = "wrapt-1.17.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3cedbfa9c940fdad3e6e941db7138e26ce8aad38ab5fe9dcfadfed9db7a54e62"},
+    {file = "wrapt-1.17.2-cp310-cp310-win32.whl", hash = "sha256:582530701bff1dec6779efa00c516496968edd851fba224fbd86e46cc6b73563"},
+    {file = "wrapt-1.17.2-cp310-cp310-win_amd64.whl", hash = "sha256:58705da316756681ad3c9c73fd15499aa4d8c69f9fd38dc8a35e06c12468582f"},
+    {file = "wrapt-1.17.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58"},
+    {file = "wrapt-1.17.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4db983e7bca53819efdbd64590ee96c9213894272c776966ca6306b73e4affda"},
+    {file = "wrapt-1.17.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9abc77a4ce4c6f2a3168ff34b1da9b0f311a8f1cfd694ec96b0603dff1c79438"},
+    {file = "wrapt-1.17.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b929ac182f5ace000d459c59c2c9c33047e20e935f8e39371fa6e3b85d56f4a"},
+    {file = "wrapt-1.17.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f09b286faeff3c750a879d336fb6d8713206fc97af3adc14def0cdd349df6000"},
+    {file = "wrapt-1.17.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a7ed2d9d039bd41e889f6fb9364554052ca21ce823580f6a07c4ec245c1f5d6"},
+    {file = "wrapt-1.17.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:129a150f5c445165ff941fc02ee27df65940fcb8a22a61828b1853c98763a64b"},
+    {file = "wrapt-1.17.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1fb5699e4464afe5c7e65fa51d4f99e0b2eadcc176e4aa33600a3df7801d6662"},
+    {file = "wrapt-1.17.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9a2bce789a5ea90e51a02dfcc39e31b7f1e662bc3317979aa7e5538e3a034f72"},
+    {file = "wrapt-1.17.2-cp311-cp311-win32.whl", hash = "sha256:4afd5814270fdf6380616b321fd31435a462019d834f83c8611a0ce7484c7317"},
+    {file = "wrapt-1.17.2-cp311-cp311-win_amd64.whl", hash = "sha256:acc130bc0375999da18e3d19e5a86403667ac0c4042a094fefb7eec8ebac7cf3"},
+    {file = "wrapt-1.17.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925"},
+    {file = "wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392"},
+    {file = "wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40"},
+    {file = "wrapt-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d"},
+    {file = "wrapt-1.17.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d18a4865f46b8579d44e4fe1e2bcbc6472ad83d98e22a26c963d46e4c125ef0b"},
+    {file = "wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98"},
+    {file = "wrapt-1.17.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82"},
+    {file = "wrapt-1.17.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9e8659775f1adf02eb1e6f109751268e493c73716ca5761f8acb695e52a756ae"},
+    {file = "wrapt-1.17.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9"},
+    {file = "wrapt-1.17.2-cp312-cp312-win32.whl", hash = "sha256:468090021f391fe0056ad3e807e3d9034e0fd01adcd3bdfba977b6fdf4213ea9"},
+    {file = "wrapt-1.17.2-cp312-cp312-win_amd64.whl", hash = "sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991"},
+    {file = "wrapt-1.17.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6ed6ffac43aecfe6d86ec5b74b06a5be33d5bb9243d055141e8cabb12aa08125"},
+    {file = "wrapt-1.17.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35621ae4c00e056adb0009f8e86e28eb4a41a4bfa8f9bfa9fca7d343fe94f998"},
+    {file = "wrapt-1.17.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a604bf7a053f8362d27eb9fefd2097f82600b856d5abe996d623babd067b1ab5"},
+    {file = "wrapt-1.17.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cbabee4f083b6b4cd282f5b817a867cf0b1028c54d445b7ec7cfe6505057cf8"},
+    {file = "wrapt-1.17.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49703ce2ddc220df165bd2962f8e03b84c89fee2d65e1c24a7defff6f988f4d6"},
+    {file = "wrapt-1.17.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8112e52c5822fc4253f3901b676c55ddf288614dc7011634e2719718eaa187dc"},
+    {file = "wrapt-1.17.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fee687dce376205d9a494e9c121e27183b2a3df18037f89d69bd7b35bcf59e2"},
+    {file = "wrapt-1.17.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:18983c537e04d11cf027fbb60a1e8dfd5190e2b60cc27bc0808e653e7b218d1b"},
+    {file = "wrapt-1.17.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:703919b1633412ab54bcf920ab388735832fdcb9f9a00ae49387f0fe67dad504"},
+    {file = "wrapt-1.17.2-cp313-cp313-win32.whl", hash = "sha256:abbb9e76177c35d4e8568e58650aa6926040d6a9f6f03435b7a522bf1c487f9a"},
+    {file = "wrapt-1.17.2-cp313-cp313-win_amd64.whl", hash = "sha256:69606d7bb691b50a4240ce6b22ebb319c1cfb164e5f6569835058196e0f3a845"},
+    {file = "wrapt-1.17.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4a721d3c943dae44f8e243b380cb645a709ba5bd35d3ad27bc2ed947e9c68192"},
+    {file = "wrapt-1.17.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:766d8bbefcb9e00c3ac3b000d9acc51f1b399513f44d77dfe0eb026ad7c9a19b"},
+    {file = "wrapt-1.17.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e496a8ce2c256da1eb98bd15803a79bee00fc351f5dfb9ea82594a3f058309e0"},
+    {file = "wrapt-1.17.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40d615e4fe22f4ad3528448c193b218e077656ca9ccb22ce2cb20db730f8d306"},
+    {file = "wrapt-1.17.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5aaeff38654462bc4b09023918b7f21790efb807f54c000a39d41d69cf552cb"},
+    {file = "wrapt-1.17.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a7d15bbd2bc99e92e39f49a04653062ee6085c0e18b3b7512a4f2fe91f2d681"},
+    {file = "wrapt-1.17.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e3890b508a23299083e065f435a492b5435eba6e304a7114d2f919d400888cc6"},
+    {file = "wrapt-1.17.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8c8b293cd65ad716d13d8dd3624e42e5a19cc2a2f1acc74b30c2c13f15cb61a6"},
+    {file = "wrapt-1.17.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c82b8785d98cdd9fed4cac84d765d234ed3251bd6afe34cb7ac523cb93e8b4f"},
+    {file = "wrapt-1.17.2-cp313-cp313t-win32.whl", hash = "sha256:13e6afb7fe71fe7485a4550a8844cc9ffbe263c0f1a1eea569bc7091d4898555"},
+    {file = "wrapt-1.17.2-cp313-cp313t-win_amd64.whl", hash = "sha256:eaf675418ed6b3b31c7a989fd007fa7c3be66ce14e5c3b27336383604c9da85c"},
+    {file = "wrapt-1.17.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5c803c401ea1c1c18de70a06a6f79fcc9c5acfc79133e9869e730ad7f8ad8ef9"},
+    {file = "wrapt-1.17.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f917c1180fdb8623c2b75a99192f4025e412597c50b2ac870f156de8fb101119"},
+    {file = "wrapt-1.17.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ecc840861360ba9d176d413a5489b9a0aff6d6303d7e733e2c4623cfa26904a6"},
+    {file = "wrapt-1.17.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb87745b2e6dc56361bfde481d5a378dc314b252a98d7dd19a651a3fa58f24a9"},
+    {file = "wrapt-1.17.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58455b79ec2661c3600e65c0a716955adc2410f7383755d537584b0de41b1d8a"},
+    {file = "wrapt-1.17.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4e42a40a5e164cbfdb7b386c966a588b1047558a990981ace551ed7e12ca9c2"},
+    {file = "wrapt-1.17.2-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:91bd7d1773e64019f9288b7a5101f3ae50d3d8e6b1de7edee9c2ccc1d32f0c0a"},
+    {file = "wrapt-1.17.2-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:bb90fb8bda722a1b9d48ac1e6c38f923ea757b3baf8ebd0c82e09c5c1a0e7a04"},
+    {file = "wrapt-1.17.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:08e7ce672e35efa54c5024936e559469436f8b8096253404faeb54d2a878416f"},
+    {file = "wrapt-1.17.2-cp38-cp38-win32.whl", hash = "sha256:410a92fefd2e0e10d26210e1dfb4a876ddaf8439ef60d6434f21ef8d87efc5b7"},
+    {file = "wrapt-1.17.2-cp38-cp38-win_amd64.whl", hash = "sha256:95c658736ec15602da0ed73f312d410117723914a5c91a14ee4cdd72f1d790b3"},
+    {file = "wrapt-1.17.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:99039fa9e6306880572915728d7f6c24a86ec57b0a83f6b2491e1d8ab0235b9a"},
+    {file = "wrapt-1.17.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2696993ee1eebd20b8e4ee4356483c4cb696066ddc24bd70bcbb80fa56ff9061"},
+    {file = "wrapt-1.17.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:612dff5db80beef9e649c6d803a8d50c409082f1fedc9dbcdfde2983b2025b82"},
+    {file = "wrapt-1.17.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62c2caa1585c82b3f7a7ab56afef7b3602021d6da34fbc1cf234ff139fed3cd9"},
+    {file = "wrapt-1.17.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c958bcfd59bacc2d0249dcfe575e71da54f9dcf4a8bdf89c4cb9a68a1170d73f"},
+    {file = "wrapt-1.17.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc78a84e2dfbc27afe4b2bd7c80c8db9bca75cc5b85df52bfe634596a1da846b"},
+    {file = "wrapt-1.17.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ba0f0eb61ef00ea10e00eb53a9129501f52385c44853dbd6c4ad3f403603083f"},
+    {file = "wrapt-1.17.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1e1fe0e6ab7775fd842bc39e86f6dcfc4507ab0ffe206093e76d61cde37225c8"},
+    {file = "wrapt-1.17.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c86563182421896d73858e08e1db93afdd2b947a70064b813d515d66549e15f9"},
+    {file = "wrapt-1.17.2-cp39-cp39-win32.whl", hash = "sha256:f393cda562f79828f38a819f4788641ac7c4085f30f1ce1a68672baa686482bb"},
+    {file = "wrapt-1.17.2-cp39-cp39-win_amd64.whl", hash = "sha256:36ccae62f64235cf8ddb682073a60519426fdd4725524ae38874adf72b5f2aeb"},
+    {file = "wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8"},
+    {file = "wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3"},
+]
+
+[[package]]
 name = "xlsxwriter"
 version = "3.2.0"
 description = "A Python module for creating Excel XLSX files."
@@ -1579,4 +1764,4 @@ requests = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "4c14d83d23d3d05dd5f347884a1f9da7001b2c9031c18b3a25e64f061614fb72"
+content-hash = "3d686245d4f577f971350313b7ef1a0a1731c1076929f8522cbd8b28a56fb9c1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,11 @@ readme = "README.md"
 requires-python = ">=3.10,<4.0"
 dependencies = [
   "flet (>=0.25.2,<0.26.0)",
-  "markitdown==0.0.1a3"
+  "markitdown==0.0.1a3",
+  "aiofiles==24.1.0",
+  "pypdf==5.3.0",
+  "pikepdf==9.5.2",
+  "pillow==11.1.0"
 ]
 
 
@@ -40,6 +44,9 @@ flet = "^0.25.2"
 markitdown = "^0.0.1a3"
 pytest = "^8.3.4"
 aiofiles = "^24.1.0"
+pypdf = "^5.3.0"
+pikepdf = "^9.5.2"
+pillow = "^11.1.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/application/pdf_compression_service.py
+++ b/src/application/pdf_compression_service.py
@@ -1,0 +1,148 @@
+import flet as ft
+import os
+import asyncio
+import pikepdf
+from PIL import Image
+import io
+import logging
+
+# ログの設定 - デバッグレベルで詳細なログを出力
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+class PDFCompressionService:
+    """PDFファイルの圧縮を行うサービスクラス
+    
+    主な機能：
+    - PDFファイル内の画像を検出し圧縮
+    - 進捗状況のリアルタイム表示
+    - 圧縮率の計算と結果表示
+    """
+    
+    async def compress_pdf(self, file_info, status: ft.Text, progress: ft.ProgressBar, compression_ratio: float = 75.0):
+        """PDFファイルを圧縮する非同期メソッド
+        
+        Args:
+            file_info: 入力PDFファイルの情報
+            status: 状態表示用のTextコンポーネント
+            progress: 進捗表示用のProgressBarコンポーネント
+            compression_ratio: 圧縮率（0-100）、デフォルト75%
+        """
+        try:
+            # UI初期化
+            progress.visible = True
+            status.value = "PDFを圧縮中..."
+            progress.value = 0
+            progress.update()
+            status.update()
+
+            # 入出力パスの設定
+            input_path = file_info.path
+            output_path = os.path.join(
+                os.path.dirname(input_path),
+                f"compressed_{os.path.basename(input_path)}"
+            )
+
+            # ログ出力
+            logger.info(f"入力ファイル: {input_path}")
+            logger.info(f"出力ファイル: {output_path}")
+            logger.info(f"圧縮率設定: {compression_ratio}%")
+
+            # 画像品質の設定（圧縮率から計算）
+            quality = max(5, 100 - compression_ratio)
+            logger.info(f"画像品質設定: {quality}")
+
+            # PDFファイルを開いて処理
+            with pikepdf.open(input_path) as pdf:
+                total_pages = len(pdf.pages)
+                logger.info(f"総ページ数: {total_pages}")
+
+                # 各ページを処理
+                for i, page in enumerate(pdf.pages):
+                    logger.info(f"ページ {i+1}/{total_pages} を処理中")
+                    
+                    # ページ内の画像を検索して処理
+                    if hasattr(page, 'Resources') and '/XObject' in page.Resources:
+                        for name, xobj in page.Resources.XObject.items():
+                            try:
+                                # 画像オブジェクトの場合のみ処理
+                                if xobj.get('/Subtype') == '/Image':
+                                    logger.info(f"画像を検出: {name}")
+                                    # すでにJPEG圧縮されている場合はスキップ
+                                    if xobj.get('/Filter') == '/DCTDecode':
+                                        logger.info(f"既存のJPEG画像をスキップ: {name}")
+                                        continue
+                                    
+                                    try:
+                                        # 画像データの取得と処理
+                                        image_data = xobj.read_raw_bytes()
+                                        img = Image.open(io.BytesIO(image_data))
+                                        logger.info(f"画像サイズ: {img.size}, モード: {img.mode}")
+                                        
+                                        # RGB形式に変換（必要な場合）
+                                        if img.mode != 'RGB':
+                                            img = img.convert('RGB')
+                                        
+                                        # 画像の圧縮
+                                        output = io.BytesIO()
+                                        img.save(output, format='JPEG', quality=int(quality), optimize=True)
+                                        xobj.write(output.getvalue(), filter_=pikepdf.Name('/DCTDecode'))
+                                        logger.info(f"画像を圧縮: {name}")
+                                    except Exception as e:
+                                        logger.warning(f"画像処理をスキップ: {str(e)}")
+                                        continue
+                            except Exception as e:
+                                logger.warning(f"XObjectの処理をスキップ: {str(e)}")
+                                continue
+
+                    # 進捗状況の更新
+                    progress.value = (i + 1) / total_pages
+                    progress.update()
+                    await asyncio.sleep(0.01)
+
+                # 圧縮したPDFを保存
+                logger.info("PDFを保存中...")
+                pdf.save(
+                    output_path,
+                    compress_streams=True,
+                    object_stream_mode=pikepdf.ObjectStreamMode.generate,
+                    recompress_flate=True
+                )
+                logger.info("PDF保存完了")
+
+            # ファイルサイズのフォーマット用関数
+            def format_size(size):
+                for unit in ['B', 'KB', 'MB', 'GB']:
+                    if size < 1024.0:
+                        return f"{size:.1f}{unit}"
+                    size /= 1024.0
+                return f"{size:.1f}GB"
+
+            # 圧縮結果の計算
+            original_size = os.path.getsize(input_path)
+            compressed_size = os.path.getsize(output_path)
+            actual_ratio = (1 - compressed_size / original_size) * 100
+
+            # 結果のログ出力
+            logger.info(f"圧縮結果 - 元サイズ: {format_size(original_size)}, "
+                       f"圧縮後: {format_size(compressed_size)}, "
+                       f"圧縮率: {actual_ratio:.1f}%")
+
+            # UI更新
+            status.value = (
+                f"圧縮完了！\n"
+                f"元のサイズ: {format_size(original_size)}\n"
+                f"圧縮後のサイズ: {format_size(compressed_size)}\n"
+                f"圧縮率: {actual_ratio:.1f}%\n"
+                f"保存先: {output_path}"
+            )
+            progress.value = 1
+            
+        except Exception as e:
+            # エラー処理
+            logger.error(f"エラーが発生: {str(e)}", exc_info=True)
+            status.value = f"エラーが発生しました: {str(e)}"
+        finally:
+            # UI更新の確実な実行
+            status.update()
+            progress.update() 

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,10 @@
 import flet as ft
 import asyncio
 from application.conversion_service import ConversionService
+from application.pdf_compression_service import PDFCompressionService
 
 def main(page: ft.Page):
-    page.title = "Markdown Converter"
+    page.title = "Markdown & PDF Converter"
     page.theme_mode = "light"
     page.padding = 0
     page.bgcolor = "#f0f4f8"
@@ -17,17 +18,58 @@ def main(page: ft.Page):
 
     conversion_service = ConversionService()
 
+    pdf_file_picker = ft.FilePicker()
+    page.overlay.append(pdf_file_picker)
+    
+    pdf_status = ft.Text(color="#1a73e8")
+    pdf_progress = ft.ProgressBar(width=400, color="#1a73e8", visible=False)
+    
+    compression_value_text = ft.Text(
+        value="75%",
+        size=16,
+        color="#4caf50",
+        weight="bold"
+    )
+
+    def on_slider_change(e):
+        compression_value_text.value = f"{int(pdf_compression_ratio.value)}%"
+        compression_value_text.update()
+
+    pdf_compression_ratio = ft.Slider(
+        min=0,
+        max=100,
+        value=75,
+        label="圧縮率",
+        width=300,
+        active_color="#4caf50",
+        inactive_color="#a5d6a7",
+        on_change=on_slider_change
+    )
+
+    pdf_compression_service = PDFCompressionService()
+
     def pick_files_result(e: ft.FilePickerResultEvent):
         if e.files:
             asyncio.run(conversion_service.process_files(e.files, status_container, total_progress, total_status))
 
     file_picker.on_result = pick_files_result
 
+    def pick_pdf_result(e: ft.FilePickerResultEvent):
+        if e.files:
+            asyncio.run(pdf_compression_service.compress_pdf(
+                e.files[0], 
+                pdf_status, 
+                pdf_progress,
+                compression_ratio=pdf_compression_ratio.value
+            ))
+
+    pdf_file_picker.on_result = pick_pdf_result
+
     page.add(
         ft.Container(
             content=ft.Column([
                 ft.Container(
-                    content=ft.Text("📝 Markdown Converter", size=32, weight="bold", color="#1a73e8"),
+                    content=ft.Text("📝 Markdown & PDF Converter", size=32, weight="bold", color="#1a73e8"),
                     margin=ft.margin.only(bottom=20)
                 ),
                 ft.Container(
@@ -35,7 +77,7 @@ def main(page: ft.Page):
                         content=ft.Row(
                             controls=[
                                 ft.Icon(ft.Icons.UPLOAD_FILE),
-                                ft.Text("ファイルを選択", size=16),
+                                ft.Text("Markdownファイルを選択", size=16),
                             ],
                             alignment=ft.MainAxisAlignment.CENTER,
                         ),
@@ -53,11 +95,54 @@ def main(page: ft.Page):
                     margin=ft.margin.only(bottom=20)
                 ),
                 ft.Container(
+                    content=ft.ElevatedButton(
+                        content=ft.Row(
+                            controls=[
+                                ft.Icon(ft.Icons.PICTURE_AS_PDF),
+                                ft.Text("PDFファイルを圧縮", size=16),
+                            ],
+                            alignment=ft.MainAxisAlignment.CENTER,
+                        ),
+                        style=ft.ButtonStyle(
+                            color="white",
+                            bgcolor="#4caf50",
+                            shadow_color="#2e7d32",
+                            elevation=5,
+                        ),
+                        on_click=lambda _: pdf_file_picker.pick_files(
+                            allow_multiple=False,
+                            allowed_extensions=["pdf"]
+                        )
+                    ),
+                    margin=ft.margin.only(bottom=20)
+                ),
+                ft.Container(
                     content=total_progress,
                     margin=ft.margin.only(bottom=10)
                 ),
                 ft.Container(
                     content=total_status,
+                    margin=ft.margin.only(bottom=20)
+                ),
+                ft.Container(
+                    content=pdf_progress,
+                    margin=ft.margin.only(bottom=10)
+                ),
+                ft.Container(
+                    content=pdf_status,
+                    margin=ft.margin.only(bottom=20)
+                ),
+                ft.Container(
+                    content=ft.Column([
+                        ft.Text("PDF圧縮設定", size=16, color="#4a4a4a"),
+                        ft.Row(
+                            controls=[
+                                pdf_compression_ratio,
+                                compression_value_text
+                            ],
+                            alignment=ft.MainAxisAlignment.CENTER
+                        )
+                    ]),
                     margin=ft.margin.only(bottom=20)
                 ),
                 ft.Container(

--- a/tests/test_pdf_compression.py
+++ b/tests/test_pdf_compression.py
@@ -1,0 +1,89 @@
+import pytest
+from pathlib import Path
+import flet as ft
+import os
+from application.pdf_compression_service import PDFCompressionService
+from unittest.mock import MagicMock, patch
+import pikepdf
+from PIL import Image
+import io
+
+@pytest.fixture
+def mock_pdf_file():
+    # テスト用のPDFファイル情報をモック
+    mock_file = MagicMock()
+    mock_file.path = "test.pdf"
+    return mock_file
+
+@pytest.fixture
+def compression_service():
+    return PDFCompressionService()
+
+@pytest.fixture
+def ui_components():
+    # UI要素のモック作成
+    status = ft.Text()
+    progress = ft.ProgressBar()
+    return status, progress
+
+async def test_pdf_compression_initialization(compression_service, mock_pdf_file, ui_components):
+    """PDF圧縮の初期化テスト"""
+    status, progress = ui_components
+    
+    with patch('pikepdf.open') as mock_open:
+        mock_pdf = MagicMock()
+        mock_pdf.pages = []
+        mock_open.return_value.__enter__.return_value = mock_pdf
+        
+        await compression_service.compress_pdf(mock_pdf_file, status, progress)
+        
+        assert progress.visible == True
+        assert status.value.startswith("PDFを圧縮中")
+
+async def test_pdf_compression_with_images(compression_service, mock_pdf_file, ui_components):
+    """画像を含むPDFの圧縮テスト"""
+    status, progress = ui_components
+    
+    with patch('pikepdf.open') as mock_open, \
+         patch('PIL.Image.open') as mock_image_open, \
+         patch('os.path.getsize') as mock_getsize:
+        
+        # PDFのモックを設定
+        mock_pdf = MagicMock()
+        mock_page = MagicMock()
+        mock_xobj = MagicMock()
+        
+        # 画像オブジェクトの設定
+        mock_xobj.get.side_effect = lambda x: '/Image' if x == '/Subtype' else None
+        mock_xobj.read_raw_bytes.return_value = b'dummy_image_data'
+        
+        # ページリソースの設定
+        mock_page.Resources = MagicMock()
+        mock_page.Resources.XObject = {'image1': mock_xobj}
+        mock_pdf.pages = [mock_page]
+        
+        mock_open.return_value.__enter__.return_value = mock_pdf
+        
+        # PILイメージのモック
+        mock_image = MagicMock()
+        mock_image.mode = 'RGB'
+        mock_image.save = MagicMock()
+        mock_image_open.return_value = mock_image
+        
+        # ファイルサイズのモック
+        mock_getsize.side_effect = lambda x: 1000 if 'compressed' in x else 2000
+        
+        await compression_service.compress_pdf(mock_pdf_file, status, progress)
+        
+        assert progress.value == 1
+        assert "圧縮完了" in status.value
+        assert "50.0%" in status.value  # 圧縮率の確認
+
+async def test_pdf_compression_error_handling(compression_service, mock_pdf_file, ui_components):
+    """エラーハンドリングのテスト"""
+    status, progress = ui_components
+    
+    with patch('pikepdf.open', side_effect=Exception("テストエラー")):
+        await compression_service.compress_pdf(mock_pdf_file, status, progress)
+        
+        assert "エラーが発生しました" in status.value 


### PR DESCRIPTION
# プルリクエスト: PDF圧縮機能の追加と依存関係の更新

このプルリクエストでは、PDF圧縮の新機能を追加し、プロジェクトの依存関係を更新しました。主な変更点は以下の通りです。

## 🆕 新機能: PDF圧縮

- [`src/application/pdf_compression_service.py`](diffhunk://#diff-6121b607f34f1a82e94de3c0c1fc3fdb9dabde64ba3ce04e175017a78ed595deR1-R148)  
  `PDFCompressionService` クラスを追加。  
  - PDF内の画像サイズを圧縮することでPDFファイルのサイズを削減  
  - `pikepdf` と `PIL` ライブラリを使用  
  - デバッグのための詳細なログを記録  

## 🔧 メインアプリケーションの更新

- [`src/main.py`](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R4-R7)  
  PDF圧縮をサポートするためのUI要素を追加。  
  - PDFファイルの選択機能（ファイルピッカー）  
  - 進捗状況を示すプログレスバー  
  - ステータス表示コンポーネント  
  - これにより、アプリはMarkdown変換に加えてPDF圧縮も対応可能に  
  - 変更箇所: [[1]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R4-R7) [[2]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R21-R80) [[3]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R97-R118) [[4]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R127-R147)  

## 📦 依存関係の更新

- [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L9-R13)  
  PDF圧縮機能に必要な新しいライブラリを追加。  
  - `aiofiles`, `pypdf`, `pikepdf`, `pillow` を追加  
  - 変更箇所: [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L9-R13) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R47-R49)  

## 🧪 テスト

- [`tests/test_pdf_compression.py`](diffhunk://#diff-75eedb457e4f37fda0603b14590c53441f678aa546b7c281371031fa9d772b38R1-R89)  
  `PDFCompressionService` クラス用のテストを追加。  
  - クラスの初期化と基本動作を検証  
  - 画像を含むPDFの処理テスト  
  - エラーハンドリングのテスト  
  - `pytest` フレームワークを使用し、ファイル処理やUIコンポーネントのモックを活用  
